### PR TITLE
Update python to 3.12 and PyYAML to 6.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The kopia command line must be in the environment path when kopia-mon is started
 
 ## Install and configure Python
 ### Using pip
-Python with minimum version 3.10 is required. It is recommended to use a virtual environment, if you know how to use it and how to get the scheduler to run the script from the correct environment.
+Python with minimum version 3.12 is required. It is recommended to use a virtual environment, if you know how to use it and how to get the scheduler to run the script from the correct environment.
 
 Installing dependencies: 
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 dataclasses-json==0.5.7
 Jinja2==3.1.2
 python-dateutil==2.8.2
-PyYAML==6.0
+PyYAML==6.0.1


### PR DESCRIPTION
OS Version: Ubuntu 22.04.5 LTS

Kopia-mon did not run out of the box for me until I made the following changes:

First, I updated the required python from 3.10 to 3.12. I tried to make 3.10 work, but I kept getting the error:

```
ImportError: cannot import name 'Self' from 'typing' (/usr/lib/python3.10/typing.py)
```

Updating to 3.12 fixed that.

Second, in 3.12, I could not compile PyYAML 6.0.

```
PyYAML Getting requirements to build wheel did not run successful
```

After searching online, it seems like that error was fixed in PyYANL 6.0.1, so I updated requirements.txt to reflect that.

After these 2 changes, I was able to run Kopia-mon on Ubuntu 22.04.5.